### PR TITLE
The better pydantic decorator detection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Use in vscode,settings.json add item
 .. code:: shell
 
     "python.linting.pylintArgs": ["--load-plugins pylint_pydantic"]
-    
+
 Tests
 ============
 .. code:: shell
@@ -30,6 +30,10 @@ Tests
     ------------------------------------
     Your code has been rated at 10.00/10
 
+FAQ
+=====================
+- How to resolve `pylint: No name 'BaseModel' in module 'pydantic'`?
+    Add `--extension-pkg-whitelist='pydantic'` parameter (see `#1961 <https://github.com/samuelcolvin/pydantic/issues/1961>`_)
 
 Other
 =====================

--- a/examples/base_model.py
+++ b/examples/base_model.py
@@ -1,3 +1,4 @@
+import pydantic
 from pydantic import BaseModel, validator, root_validator, constr
 
 
@@ -23,4 +24,17 @@ class A(BaseModel):
 
     @root_validator(pre=True)
     def valid_root_pre(cls, values):
+        return values
+
+    @pydantic.root_validator
+    def valid_pydantic_qualname(cls, values):
+        return values
+
+    @pydantic.root_validator(pre=True)
+    def valid_pydantic_qualname_pre(cls, values):
+        return values
+
+    @root_validator
+    def valid_static_method(cls, values):
+        values[cls.__name__] = cls.__name__
         return values

--- a/pylint_pydantic/__init__.py
+++ b/pylint_pydantic/__init__.py
@@ -1,37 +1,48 @@
-from astroid.node_classes import ImportFrom
-from astroid import FunctionDef, Name, Call
-from pylint.lint import PyLinter
-from pylint.checkers.classes import ClassChecker
-from pylint.checkers.variables import VariablesChecker
-from pylint_plugin_utils import suppress_message
-from pydantic import __all__ as import_module_list
+from astroid import MANAGER, Attribute, Call, FunctionDef, Name
 
 
 def is_validator_method(node: FunctionDef):
-    validator_method_names = ["validator", "root_validator"]
+    validator_method_names = {
+        "validator",
+        "root_validator",
+    }
+
     if not node.decorators:
         return False
 
     for decorator in node.decorators.get_children():
-        # no arguments
-        if isinstance(decorator, Name) and decorator.name in validator_method_names:
+        # @validator(pre=True)
+        if isinstance(decorator, Call):
+            # transform to @validator case
+            decorator = decorator.func
+
+        # @validator
+        if (
+            isinstance(decorator, Name)
+            and decorator.name in validator_method_names
+        ):
             return True
-        # arguments
-        if isinstance(decorator, Call) and getattr(decorator.func, "name", None) in validator_method_names:
+
+        # @pydantic.validator
+        if (
+            isinstance(decorator, Attribute)
+            and decorator.attrname in validator_method_names
+        ):
             return True
 
     return False
 
 
-def is_pydantic_property(node: ImportFrom):
-    if node.names and node.modname == "pydantic":
-        for name, _ in node.names:
-            if name in import_module_list:
-                return True
-    return False
+def transform(node: FunctionDef):
+    if is_validator_method(node):
+        node.type = "classmethod"
 
 
-def register(linter: PyLinter):
-    suppress_message(linter, ClassChecker.visit_functiondef, 'no-self-argument', is_validator_method)
-    suppress_message(linter, ClassChecker.leave_functiondef, 'no-self-use', is_validator_method)
-    suppress_message(linter, VariablesChecker.visit_importfrom, 'no-name-in-module', is_pydantic_property)
+MANAGER.register_transform(FunctionDef, transform)
+
+
+def register(linter):
+    # Needed for registering the plugin.
+    # We don't need to do anything in the register function of the plugin since
+    # we are not modifying anything in the linter itself.
+    pass

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,14 @@ setup(
         'Environment :: Console',
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Quality Assurance',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],
     keywords=['pylint', 'pydantic'],
-    python_requires=">=3.9",
+    python_requires=">=3.6",
     install_requires=[
-        'pylint-plugin-utils>=0.5',
         'pylint>=2.0',
     ],
 )


### PR DESCRIPTION

This PR addressed some limitations mentioned below:

1. There is no reason only to support python 3.9. Pydantic works well with python 3.6 and higher.
2. `@pydantic.validator` is not recognized.
3. `no-self-argument` error is just off, but pylint keeps complaining about missing class-level attributes, e.g `cls.__name__`. The better approach would be to transform decorated method into class method.
4. `no-name-in-module` could be resolved by `extension-pkg-whitelist` option.  This will help pylint understand extension members and keep complaining about true `no-name-in-module` errors.

@fcfangcc 


