### PR TITLE
docs: update format for VSCode plugin setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,8 @@ Use in vscode,settings.json add item
 .. code:: shell
 
     "pylint.args": ["--load-plugins", "pylint_pydantic"]
+    # in old vscode version maybe
+    "python.linting.pylintArgs": ["--load-plugins", "pylint_pydantic"]
 
 Tests
 ============

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Use in vscode,settings.json add item
 
 .. code:: shell
 
-    "python.linting.pylintArgs": ["--load-plugins", "pylint_pydantic"]
+    "pylint.args": ["--load-plugins", "pylint_pydantic"]
 
 Tests
 ============


### PR DESCRIPTION
It looks like VSCode has changed some formatting for its JSON config. When using the recommended setting, there's a warning, and the plugin wasn't loading for me:

<img width="500" alt="image" src="https://github.com/fcfangcc/pylint-pydantic/assets/2266893/7a38888b-3a54-448f-ad02-8450029ee023">

When adding the preference via the GUI, this is the way the pref is written to the JSON file.