### PR TITLE
__init__: Solve incosistent-return-statements

### DIFF
--- a/pylint_pydantic/__init__.py
+++ b/pylint_pydantic/__init__.py
@@ -92,6 +92,7 @@ def transform_pydantic_json(node: nodes.Subscript):
         if inferred and inferred.is_subtype_of("pydantic.types.Json"):
             new_subscript = astroid.extract_node(node.slice.as_string())
             return new_subscript
+    return None
 
 
 def register(linter):


### PR DESCRIPTION
Scanning the code, pylint returned warning R1710
that not all paths in transform_pydantic_json return a value. This commit solves this issue by adding return None at the bottom of the function.