### PR TITLE
Fix transform function to always return node

### DIFF
--- a/pylint_pydantic/__init__.py
+++ b/pylint_pydantic/__init__.py
@@ -75,6 +75,7 @@ def _is_classmethod_decorator(node: FunctionDef):
 def transform(node: FunctionDef):
     if _is_classmethod_decorator(node):
         node.type = "classmethod"
+    return node
 
 
 def is_pydantic_config_class(node: ClassDef):


### PR DESCRIPTION
Fixes #40

## Summary
Adds missing return statement in `transform(`) function to comply with Astroid's transform contract.

## Problem
The `transform()` function currently returns `None` implicitly in most cases, which can break the transform chain when other plugins with `FunctionDef` transforms are loaded after `pylint-pydantic`.

## Changes
- Added `return node` statement at line 78
- Ensures the function always returns the node, even when unmodified
- Consistent with how `transform_pydantic_json()` already handles returns in the same file

## Testing
- All existing tests pass
- Verified transform chaining works correctly with multiple plugins loaded in different orders

## Related
- [Astroid issue #809](https://github.com/pylint-dev/astroid/issues/809) (transform chain breaking when transforms return None)

## Impact
- **Current behaviour:** Works when plugin is loaded last (typical case)
- **Fixed behaviour:** Also works correctly when loaded before other transform-based plugins
- **Risk:** None - this is a safe, defensive fix that only improves correctness
